### PR TITLE
CljMigration supports Mongo

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.mjachimowicz/ragtime-clj "0.1.1"
+(defproject com.mjachimowicz/ragtime-clj "0.1.2"
   :description "Extension for ragtime that handles migrations as clj files"
   :url         "https://github.com/mariusz-jachimowicz-83/ragtime-clj"
   :license     {:name "Eclipse Public License"

--- a/src/ragtime/clj/core.clj
+++ b/src/ragtime/clj/core.clj
@@ -12,8 +12,8 @@
 (defrecord CljMigration [id up down]
   ragtime.protocols/Migration
   (id [_] id)
-  (run-up!   [_ db] (execute-clj! (:db-spec db) up))
-  (run-down! [_ db] (execute-clj! (:db-spec db) down)))
+  (run-up!   [_ db] (execute-clj! (or (:db-spec db) db) up))
+  (run-down! [_ db] (execute-clj! (or (:db-spec db) db) down)))
 
 (defn clj-migration
   "Create a Ragtime migration from a map with a unique :id, and :up and :down


### PR DESCRIPTION
The CljMigration implementation of ragtime.protocols/Migration assumes an SqlDatabase.
This patch makes it work with Mongo databases as well.